### PR TITLE
Revert "Group variables for storage locations"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,6 @@ loki_identifier: loki
 loki_base_path: "/{{ loki_identifier }}"
 loki_config_path: "{{ loki_base_path }}/config"
 loki_data_path: "{{ loki_base_path }}/data"
-loki_common_path_prefix: "{{ loki_base_path }}"
-loki_storage_chunks_directory: "{{ loki_base_path }}/chunks" # Storage locations in container
-loki_storage_rules_directory: "{{ loki_base_path }}/rules" # Storage locations in container
 
 # renovate: datasource=docker depName=grafana/loki versioning=semver
 loki_version: 3.5.0
@@ -181,6 +178,11 @@ loki_systemd_wanted_services_list: []
 # Despite the confusing name, this has nothing to do with authentication.
 # If you're exposing Loki publicly, consider setting up Basic Authentication for it (e.g. `loki_container_labels_middleware_basic_auth_*`).
 loki_auth_enabled: true
+
+# Storage locations in container
+loki_common_path_prefix: "/loki"
+loki_storage_chunks_directory: "{{ loki_common_path_prefix }}/chunks"
+loki_storage_rules_directory: "{{ loki_common_path_prefix }}/rules"
 
 # Controls whether Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs


### PR DESCRIPTION
This reverts commit dc747306eb952c350d11e0e7b1f56be507fbf2f0, because `loki_common_path_prefix` is a variable to be used for specifying a directory location inside a container with the configuration file mounted to the container, and therefore it has essentially nothing to do with `loki_base_path` even if their values are same (/loki). I've confirmed this fixes https://github.com/mother-of-all-self-hosting/mash-playbook/issues/533 on my server. 